### PR TITLE
Avoid finding source packages in dnf_context_install()

### DIFF
--- a/libdnf/dnf-context.cpp
+++ b/libdnf/dnf-context.cpp
@@ -1769,7 +1769,7 @@ dnf_context_install (DnfContext *context, const gchar *name, GError **error)
     }
 
     subject = hy_subject_create(name);
-    selector = hy_subject_get_best_selector(subject, priv->sack);
+    selector = hy_subject_get_best_selector(subject, priv->sack, false);
     selector_matches = hy_selector_matches(selector);
     if (selector_matches->len == 0) {
         g_set_error(error,
@@ -1866,7 +1866,7 @@ dnf_context_update(DnfContext *context, const gchar *name, GError **error)
     }
 
     g_auto(HySubject) subject = hy_subject_create(name);
-    g_auto(HySelector) selector = hy_subject_get_best_selector(subject, priv->sack);
+    g_auto(HySelector) selector = hy_subject_get_best_selector(subject, priv->sack, FALSE);
     g_autoptr(GPtrArray) selector_matches = hy_selector_matches(selector);
     if (selector_matches->len == 0) {
         g_set_error(error,

--- a/libdnf/hy-subject.h
+++ b/libdnf/hy-subject.h
@@ -102,7 +102,8 @@ int hy_possibilities_next_module_form(HyPossibilities iter, HyModuleForm *out_mo
 
 HyQuery hy_subject_get_best_solution(HySubject subject, DnfSack *sack, HyForm *forms,
                                      HyNevra *nevra, gboolean icase, gboolean with_nevra,
-                                     gboolean with_provides, gboolean with_filenames);
+                                     gboolean with_provides, gboolean with_filenames,
+                                     gboolean with_src);
 HyQuery hy_subject_get_best_query(HySubject subject, DnfSack *sack, gboolean with_provides);
 
 /**
@@ -115,11 +116,12 @@ HyQuery hy_subject_get_best_query(HySubject subject, DnfSack *sack, gboolean wit
 * @param forms HyForm *forms or NULL
 * @param obsoletes If TRUE, obsoletes will be added to result
 * @param reponame Id of repo
+* @param with_src Include source packages
 * @return HySelector
 */
 HySelector hy_subject_get_best_sltr(HySubject subject, DnfSack *sack, HyForm *forms, bool obsoletes,
-                                    const char *reponame);
-HySelector hy_subject_get_best_selector(HySubject subject, DnfSack *sack);
+                                    const char *reponame, bool with_src);
+HySelector hy_subject_get_best_selector(HySubject subject, DnfSack *sack, bool with_src);
 int hy_nevra_possibility(const char *nevra_str, int re, HyNevra nevra);
 
 G_END_DECLS

--- a/python/hawkey/subject-py.c
+++ b/python/hawkey/subject-py.c
@@ -318,7 +318,7 @@ get_best_parser(_SubjectObject *self, PyObject *args, PyObject *kwds, HyNevra *n
     gboolean c_with_filenames = with_filenames == NULL || PyObject_IsTrue(with_filenames);
     csack = sackFromPyObject(sack);
     HyQuery query = hy_subject_get_best_solution(self->pattern, csack, cforms, nevra, self->icase,
-                                                 c_with_nevra, c_with_provides, c_with_filenames);
+        c_with_nevra, c_with_provides, c_with_filenames, TRUE);
 
     return queryToPyObject(query, sack, &query_Type);
 }
@@ -366,7 +366,7 @@ get_best_selector(_SubjectObject *self, PyObject *args, PyObject *kwds)
     }
     DnfSack *csack = sackFromPyObject(sack);
     HySelector c_selector = hy_subject_get_best_sltr(self->pattern, csack, cforms, c_obsoletes,
-                                                     reponame);
+                                                     reponame, TRUE);
     PyObject *selector = SelectorToPyObject(c_selector, sack);
     Py_INCREF(selector);
     return selector;


### PR DESCRIPTION
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1565647

I think this was a subtle regression introduced from
porting `dnf_context_install()` to match the dnf behavior.
That was in: https://github.com/rpm-software-management/libdnf/pull/204

Basically we started looking at source packages particularly when matching
`Provides`.

I'm really uncertain if there are actually any use cases at all
for finding source packages from these APIs, but I went the
maximally conservative route and added booleans.